### PR TITLE
Add a -wanted-version flag so the cli itself can error out when it isn't the correct version

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -9,7 +9,12 @@ import (
 )
 
 func writeGoCode(flags Flags, parsedFile ParsedFile, builder *strings.Builder) {
-	builder.WriteString("// Generated code by github.com/choonkeat/sumtype-go\npackage ")
+	builder.WriteString("// Generated code by github.com/choonkeat/sumtype-go")
+	if flags.actualVersion != "" {
+		builder.WriteString("@")
+		builder.WriteString(flags.actualVersion)
+	}
+	builder.WriteString("\npackage ")
 	builder.WriteString(parsedFile.PackageName)
 	builder.WriteString("\n\n")
 	parsedFile.Imports = append(parsedFile.Imports, "encoding/json", "fmt")

--- a/main.go
+++ b/main.go
@@ -50,6 +50,10 @@ func main() {
 		panic(err)
 	}
 
+	if len(parsedFile.Data) == 0 {
+		return
+	}
+
 	var builder strings.Builder
 	writeGoCode(flags, parsedFile, &builder)
 	formattedCode, err := format.Source([]byte(builder.String()))

--- a/parse.go
+++ b/parse.go
@@ -5,8 +5,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 )
 
@@ -39,7 +39,7 @@ func parseFile(flags Flags) (ParsedFile, error) {
 		return ParsedFile{}, err
 	}
 
-	src, err := ioutil.ReadFile(flags.inputFile)
+	src, err := os.ReadFile(flags.inputFile)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
```
$ sumtype-go -wanted-version 123 -input demo.go && echo ok || echo fail
version wanted 123, got v0.4.5-0.20240924235331-7c2067ce76e3
fail
```

```
$ sumtype-go -wanted-version v0.4.5 -input demo.go && echo ok || echo fail
ok
```

convenient way to ensure we use the same version everywhere

```sh
SUMTYPE_GO_VERSION=v0.4.5
sumtype-go -wanted-version ${SUMTYPE_GO_VERSION} || go install github.com/choonkeat/sumtype-go@${SUMTYPE_GO_VERSION}
sumtype-go -wanted-version ${SUMTYPE_GO_VERSION} -input demo.go
```

